### PR TITLE
overlays: use the on-board 24MHz oscillator for mclk

### DIFF
--- a/arch/arm/boot/dts/overlays/wm8960-soundcard-overlay.dts
+++ b/arch/arm/boot/dts/overlays/wm8960-soundcard-overlay.dts
@@ -3,80 +3,85 @@
 /plugin/;
 
 / {
-	compatible = "brcm,bcm2835";
+    compatible = "brcm,bcm2708";
 
-	fragment@0 {
-		target = <&i2s>;
-		__overlay__ {
-			status = "okay";
-		};
-	};
-
-	fragment@1 {
+    fragment@0 {
+        target = <&i2s>;
+        __overlay__ {
+            status = "okay";
+        };
+    };
+    fragment@1 {
 		target-path="/";
 		__overlay__ {
-			wm8960_mclk: wm8960_mclk {
-				compatible = "fixed-clock";
-				#clock-cells = <0>;
-				clock-frequency = <12288000>;
-			};
+                        wm8960_mclk: wm8960_mclk {
+                                compatible = "fixed-clock";
+                                #clock-cells = <0>;
+				clock-frequency = <24000000>;
+				clock-output-names = "wm8960-mclk";
+				status = "okay";
+                        };
 		};
-	};
-	fragment@2 {
+    };
+    fragment@2 {
 		target = <&i2c1>;
 		__overlay__ {
 			#address-cells = <1>;
 			#size-cells = <0>;
 			status = "okay";
 
-			wm8960: wm8960 {
+			wm8960: wm8960{
 				compatible = "wlf,wm8960";
 				reg = <0x1a>;
 				#sound-dai-cells = <0>;
 				AVDD-supply = <&vdd_5v0_reg>;
 				DVDD-supply = <&vdd_3v3_reg>;
-			};
-		};
-	};
-
-
-	fragment@3 {
-		target = <&sound>;
-		slave_overlay: __overlay__ {
-			compatible = "simple-audio-card";
-			simple-audio-card,format = "i2s";
-			simple-audio-card,name = "wm8960-soundcard"; 
-			status = "okay";
-
-			simple-audio-card,widgets =
-				"Microphone", "Mic Jack",
-				"Line", "Line In",
-				"Line", "Line Out",
-				"Speaker", "Speaker",
-				"Headphone", "Headphone Jack";
-			simple-audio-card,routing =
-				"Headphone Jack", "HP_L",
-				"Headphone Jack", "HP_R",
-				"Speaker", "SPK_LP",
-				"Speaker", "SPK_LN",
-				"LINPUT1", "Mic Jack",
-				"LINPUT3", "Mic Jack",
-				"RINPUT1", "Mic Jack",
-				"RINPUT2", "Mic Jack";
-
-			simple-audio-card,cpu {
-				sound-dai = <&i2s>;
-			};
-			dailink0_slave: simple-audio-card,codec {
-				sound-dai = <&wm8960>;
 				clocks = <&wm8960_mclk>;
 				clock-names = "mclk";
+				wlf,shared-lrclk;
 			};
 		};
-	};
+    };
 
-	__overrides__ {
-		alsaname = <&slave_overlay>,"simple-audio-card,name";
-		compatible = <&wm8960>,"compatible";
-	};
+
+    fragment@3 {
+        target = <&sound>;
+        slave_overlay: __overlay__ {
+                compatible = "simple-audio-card";
+                simple-audio-card,format = "i2s";
+                simple-audio-card,name = "seeed-2mic-voicecard"; 
+                status = "okay";
+                simple-audio-card,widgets =
+                        "Microphone", "Mic Jack",
+                        "Line", "Line In",
+                        "Line", "Line Out",
+                        "Speaker", "Speaker",
+                        "Headphone", "Headphone Jack";
+                simple-audio-card,routing =
+                        "Headphone Jack", "HP_L",
+                        "Headphone Jack", "HP_R",
+                        "Speaker", "SPK_LP",
+                        "Speaker", "SPK_LN",
+                        "LINPUT1", "Mic Jack",
+                        "LINPUT3", "Mic Jack",
+                        "RINPUT1", "Mic Jack",
+                        "RINPUT2", "Mic Jack";
+
+
+
+
+                simple-audio-card,cpu {
+                    sound-dai = <&i2s>;
+                };
+                dailink0_slave: simple-audio-card,codec {
+                    sound-dai = <&wm8960>;
+
+                };
+        };
+    };
+
+    __overrides__ {
+        alsaname = <&slave_overlay>,"simple-audio-card,name";
+        compatible = <&wm8960>,"compatible";
+    };
 };


### PR DESCRIPTION
The previous overlays required modifying the wm8960 source file as ReSpeaker did. The main effect of its modification is to force the use of SYSCLK_PLL as the clock source. After the modification, you can directly use MCLK  as the clock source and the wm8960 does not need any modification.
https://github.com/respeaker/seeed-voicecard/blob/master/wm8960.c#L1207-L1225